### PR TITLE
Respect timestamps when writing into DB

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -31,6 +31,6 @@ jobs:
         python -m pytest -vvv tests
     - name: Integration tests
       run: |
-        wavdb initdb ./tmp
-        wavdb import data/. ./tmp
+        wavdb initdb ./tmp data/.
+        wavdb import ./tmp data/.
     

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -36,5 +36,5 @@ jobs:
       uses: codecov/codecov-action@v3
     - name: Integration tests
       run: |
-        wavdb initdb ./tmp
-        wavdb import data/. ./tmp
+        wavdb initdb ./tmp data/.
+        wavdb import ./tmp data/.

--- a/notebooks/querydb.ipynb
+++ b/notebooks/querydb.ipynb
@@ -8,8 +8,9 @@
    "source": [
     "%load_ext autoreload\n",
     "%autoreload\n",
+    "import IPython.display as ipd\n",
     "import numpy as np\n",
-    "from uwloc.data.tile import read_device_slice, get_devices, read_slice, to_pandas\n",
+    "from uwloc.data.tile import read_device_slice, get_devices, read_slice, to_pandas, read_start_date\n",
     "import os\n",
     "import matplotlib.pyplot as plt"
    ]
@@ -40,7 +41,9 @@
     "dbpath = os.path.expanduser(\"~/wdb\")\n",
     "devices = get_devices(dbpath)\n",
     "print(devices)\n",
-    "dev1 = devices[0]\n"
+    "dev1 = devices[0]\n",
+    "start_date = read_start_date(dbpath)\n",
+    "print(f\"Start date: {start_date}\")\n"
    ]
   },
   {
@@ -57,8 +60,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = to_pandas(dbpath)\n",
-    "df"
+    "# This can load a lot of data into memory\n",
+    "# df = to_pandas(dbpath)\n",
+    "# len(df.iloc[0]['sample'])"
    ]
   },
   {
@@ -91,10 +95,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "audio = read_device_slice(dbpath, dev1, 5, 6)\n",
-    "print(f\"{type(audio)}, shape: {audio.shape}\")\n",
-    "print(audio)\n",
+    "start = 5500\n",
+    "dur = 600\n",
+    "audio = read_device_slice(dbpath, dev1, start, start+dur)\n",
     "plot_audio(audio, dev1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ipd.Audio(audio, rate=192000)"
    ]
   },
   {
@@ -111,11 +124,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "slices = read_slice(dbpath, 1,12)\n",
+    "slices = read_slice(dbpath, 0,55)\n",
     "print(slices.shape)\n",
     "for (s,d) in zip(slices, devices):\n",
     "    plot_audio(s, d)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -134,7 +154,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "matplotlib",
     "jupyter==1.0.0",
     "types-pytz",
+    "types-python-dateutil",
 ]
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
     "hatch",
     "matplotlib",
     "jupyter==1.0.0",
+    "types-pytz",
 ]
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"

--- a/src/uwloc/data/main.py
+++ b/src/uwloc/data/main.py
@@ -29,7 +29,7 @@ def initdb(
     start_date: datetime = _find_start_date(wavs_dir)
     typer.echo(f"Initializing TileDB in {dbpath} with start date: {start_date}")
     create(dbpath, start_date, max_units, max_hrs)
-    import_wavs(wavs_dir, dbpath)
+    import_wavs(dbpath, wavs_dir)
 
 
 @app.command(name="import")

--- a/src/uwloc/data/main.py
+++ b/src/uwloc/data/main.py
@@ -33,7 +33,10 @@ def initdb(
 
 
 @app.command(name="import")
-def import_wavs(wavs_dir: str, dbpath: str) -> None:
+def import_wavs(
+    dbpath: str,
+    wavs_dir: str,
+) -> None:
     typer.echo(f"Uploading WAV files from {wavs_dir} {dbpath}")
     if not os.path.isdir(dbpath):
         fail(f"TileDB '{dbpath}' not found. Run initdb command first.")

--- a/src/uwloc/data/main.py
+++ b/src/uwloc/data/main.py
@@ -1,4 +1,5 @@
 import glob
+import logging
 import os
 from datetime import datetime, timezone
 
@@ -8,8 +9,12 @@ from typing_extensions import Annotated
 from .tile import MAX_HOURS, MAX_UNITS, create, init_tiledb, tidy, write_row
 from .wav import read_wav, read_wav_metadata
 
-app = typer.Typer()
 WAV_PATTERN = "**/*.[wW][aA][vV]"
+app = typer.Typer()
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s %(levelname)s %(module)s %(funcName)s %(message)s"
+)
 
 
 def fail(msg: str) -> None:
@@ -44,15 +49,15 @@ def import_wavs(
     files = sorted(glob.iglob(os.path.join(wavs_dir, WAV_PATTERN), recursive=True))
     for f in files:
         try:
-            (device, timestamp, rate, data) = read_wav(f)
+            device, timestamp, rate, data = read_wav(f)
             if len(device) == 0:
-                typer.echo(f"{f} is missing the Device ID, skipping")
+                logger.warning(f"{f} is missing the Device ID, skipping")
                 continue
             secs = data.size // rate
             typer.echo(f"Importing  {f}. Timestamp: {timestamp} Device: {device}, secs: {secs}")
             write_row(dbpath, device, timestamp, data)
         except Exception as e:
-            typer.echo(f"Warning: Failed to import {f}. {e}", err=True)
+            logger.warning(f"Warning: Failed to import {f}. {e}")
     tidy(dbpath)
 
 
@@ -61,13 +66,11 @@ def _find_start_date(wavs_dir: str) -> datetime:
     files = sorted(glob.iglob(os.path.join(wavs_dir, WAV_PATTERN), recursive=True))
     for f in files:
         try:
-            (_, timestamp) = read_wav_metadata(f)
+            _, timestamp = read_wav_metadata(f)
             start_date = min(timestamp, start_date)
         except Exception as e:
-            typer.echo(f"Warning: Failed to read {f}. {e}", err=True)
+            logger.warning(f"Warning: Failed to read {f}. {e}")
     return start_date
 
 
-if __name__ == "__main__":
-    init_tiledb()
-    app()
+init_tiledb()

--- a/src/uwloc/data/main.py
+++ b/src/uwloc/data/main.py
@@ -10,11 +10,13 @@ from .tile import MAX_HOURS, MAX_UNITS, create, init_tiledb, tidy, write_row
 from .wav import read_wav, read_wav_metadata
 
 WAV_PATTERN = "**/*.[wW][aA][vV]"
-app = typer.Typer()
+
 logger = logging.getLogger(__name__)
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s %(levelname)s %(module)s %(funcName)s %(message)s"
 )
+
+app = typer.Typer()
 
 
 def fail(msg: str) -> None:
@@ -57,7 +59,7 @@ def import_wavs(
             typer.echo(f"Importing  {f}. Timestamp: {timestamp} Device: {device}, secs: {secs}")
             write_row(dbpath, device, timestamp, data)
         except Exception as e:
-            logger.warning(f"Warning: Failed to import {f}. {e}")
+            logger.error(f"Failed to import {f}. {e}")
     tidy(dbpath)
 
 
@@ -69,7 +71,7 @@ def _find_start_date(wavs_dir: str) -> datetime:
             _, timestamp = read_wav_metadata(f)
             start_date = min(timestamp, start_date)
         except Exception as e:
-            logger.warning(f"Warning: Failed to read {f}. {e}")
+            logger.warning(f"Failed to read {f}. {e}")
     return start_date
 
 

--- a/src/uwloc/data/main.py
+++ b/src/uwloc/data/main.py
@@ -1,13 +1,15 @@
 import glob
 import os
+from datetime import datetime, timezone
 
 import typer
 from typing_extensions import Annotated
 
-from .tile import MAX_HOURS, MAX_UNITS, create, init_tiledb, write_row
-from .wav import read_wav
+from .tile import MAX_HOURS, MAX_UNITS, create, init_tiledb, tidy, write_row
+from .wav import read_wav, read_wav_metadata
 
 app = typer.Typer()
+WAV_PATTERN = "**/*.[wW][aA][vV]"
 
 
 def fail(msg: str) -> None:
@@ -18,13 +20,16 @@ def fail(msg: str) -> None:
 @app.command()
 def initdb(
     dbpath: str,
+    wavs_dir: str,
     max_units: Annotated[
         int, typer.Argument(help="Maximum number of units (rows) to store in the array")
     ] = MAX_UNITS,
     max_hrs: Annotated[int, typer.Argument(help="Maximum amount of hours to store in the array")] = MAX_HOURS,
 ) -> None:
-    typer.echo(f"Initializing TileDB in {dbpath}")
-    create(dbpath, max_units, max_hrs)
+    start_date: datetime = _find_start_date(wavs_dir)
+    typer.echo(f"Initializing TileDB in {dbpath} with start date: {start_date}")
+    create(dbpath, start_date, max_units, max_hrs)
+    import_wavs(wavs_dir, dbpath)
 
 
 @app.command(name="import")
@@ -33,19 +38,31 @@ def import_wavs(wavs_dir: str, dbpath: str) -> None:
     if not os.path.isdir(dbpath):
         fail(f"TileDB '{dbpath}' not found. Run initdb command first.")
 
-    files = glob.iglob(os.path.join(wavs_dir, "**/*.[wW][aA][vV]"), recursive=True)
-    # TODO: Handle multiple recording files from the same device. These need to be sorted
-    # and laid out correctly in the array
+    files = sorted(glob.iglob(os.path.join(wavs_dir, WAV_PATTERN), recursive=True))
     for f in files:
-        (device, timestamp, rate, data) = read_wav(f)
-        if len(device) == 0:
-            typer.echo(f"{f} is missing the Device ID, skipping")
-            continue
-        secs = data.size // rate
-        typer.echo(
-            f"Importing  {f}. Timestamp: {timestamp} Device: {device}, rate: {rate}, dtype: {data.dtype}, secs: {secs}"
-        )
-        write_row(dbpath, device, timestamp, data)
+        try:
+            (device, timestamp, rate, data) = read_wav(f)
+            if len(device) == 0:
+                typer.echo(f"{f} is missing the Device ID, skipping")
+                continue
+            secs = data.size // rate
+            typer.echo(f"Importing  {f}. Timestamp: {timestamp} Device: {device}, secs: {secs}")
+            write_row(dbpath, device, timestamp, data)
+        except Exception as e:
+            typer.echo(f"Warning: Failed to import {f}. {e}", err=True)
+    tidy(dbpath)
+
+
+def _find_start_date(wavs_dir: str) -> datetime:
+    start_date = datetime.max.replace(tzinfo=timezone.utc)
+    files = sorted(glob.iglob(os.path.join(wavs_dir, WAV_PATTERN), recursive=True))
+    for f in files:
+        try:
+            (_, timestamp) = read_wav_metadata(f)
+            start_date = min(timestamp, start_date)
+        except Exception as e:
+            typer.echo(f"Warning: Failed to read {f}. {e}", err=True)
+    return start_date
 
 
 if __name__ == "__main__":

--- a/src/uwloc/data/wav.py
+++ b/src/uwloc/data/wav.py
@@ -1,13 +1,28 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Tuple
 
 import numpy as np
 import numpy.typing as npt
+import pytz
 import scipy.io.wavfile as wf
 import wavinfo
 
 logger = logging.getLogger(__name__)
+
+
+def parse_date(dstr: str) -> datetime:
+    assert "(UTC" in dstr, "Expected a timezone suffix of the form: (UTC-<offset>)"
+    DATE_FORMAT = "%H:%M:%S %d/%m/%Y"
+    parts = dstr.split(" ")  # TIME, DATE, TIMEZONE
+    sdate_notz = " ".join(parts[0:2])
+    offset_hr = int(parts[2].replace("(UTC", "").replace(")", "").strip() or 0)
+    date = (
+        datetime.strptime(sdate_notz, DATE_FORMAT)
+        .replace(tzinfo=pytz.FixedOffset(offset_hr * 60))
+        .astimezone(timezone.utc)
+    )
+    return date
 
 
 def read_wav(file: str) -> Tuple[str, datetime, int, npt.NDArray[np.int16]]:
@@ -17,14 +32,23 @@ def read_wav(file: str) -> Tuple[str, datetime, int, npt.NDArray[np.int16]]:
     Returns:
     Tuple of (device Id, recording timestamp, sample rate, data)
     """
+    device_id, date = read_wav_metadata(file)
+    if len(device_id) == 0:
+        return ("", datetime.min, 0, np.empty(0, dtype=np.int16))
+
+    # Read data:
+    rate, data = wf.read(file)
+    return (device_id, date, rate, data)
+
+
+def read_wav_metadata(file: str) -> Tuple[str, datetime]:
     AUDIOMOTH = "AudioMoth"
-    DATE_FORMAT = "%H:%M:%S %d/%m/%Y (%Z)"
 
     # Read metadata:
     info = wavinfo.WavInfoReader(file)
     if not hasattr(info.info, "artist"):
         logger.warning(f"'{file}' is missing the Device ID in the artist metadata")
-        return ("", datetime.min, 0, np.empty(0, dtype=np.int16))
+        return ("", datetime.min)
 
     # Artist field looks like this:
     # 'AudioMoth 24F3190361DA539A'
@@ -33,8 +57,5 @@ def read_wav(file: str) -> Tuple[str, datetime, int, npt.NDArray[np.int16]]:
     # Comment looks like this:
     # 'Recorded at 15:09:20 25/04/2023 (UTC) by AudioMoth 24F3190361DA539A ...'
     str_date = cmt[len("Recorded at ") : cmt.index(f"by {AUDIOMOTH}") - 1]
-    date = datetime.strptime(str_date, DATE_FORMAT)
-
-    # Read data:
-    rate, data = wf.read(file)
-    return (device_id, date, rate, data)
+    date = parse_date(str_date)
+    return (device_id, date)

--- a/src/uwloc/data/wav.py
+++ b/src/uwloc/data/wav.py
@@ -12,7 +12,9 @@ logger = logging.getLogger(__name__)
 
 
 def parse_date(dstr: str) -> datetime:
-    assert "(UTC" in dstr, "Expected a timezone suffix of the form: (UTC-<offset>)"
+    if "(UTC" not in dstr:
+        raise ValueError("Expected a timezone suffix of the form: (UTC-<offset>)")
+
     DATE_FORMAT = "%H:%M:%S %d/%m/%Y"
     parts = dstr.split(" ")  # TIME, DATE, TIMEZONE
     sdate_notz = " ".join(parts[0:2])

--- a/tests/uwloc/data/test_wav.py
+++ b/tests/uwloc/data/test_wav.py
@@ -1,0 +1,15 @@
+import pytest
+
+from uwloc.data.wav import parse_date
+
+dates = [
+    ("10:32:00 17/05/2023 (UTC-4)", "2023-05-17T14:32:00+00:00"),
+    ("10:32:00 17/05/2023 (UTC+4)", "2023-05-17T06:32:00+00:00"),
+    ("10:32:00 17/05/2023 (UTC)", "2023-05-17T10:32:00+00:00"),
+]
+
+
+@pytest.mark.parametrize("date, expected_iso", dates)
+def test_parse_date(date: str, expected_iso: str) -> None:
+    d = parse_date(date)
+    assert d.isoformat() == expected_iso


### PR DESCRIPTION
The previous version of the code would always write any imported data at the start of the TileDB array. In this PR we:

- Compute the earliest timestamp across all imported wav files to establish a `start_date` for the DB
- When inserting, compute the right offset for the data based on the file's timestamp
- Error check for inserts outside of the boundaries of the DB
- Add support for parsing timestamps out of the WAV that include a UTC+offset timezone
- Only do consolidate/vacuum at the end of all writes (instead of on every write)

TODO: Convert the functions in `tile.py` into a stateful class to avoid many repeated operations (like file opens and reading schema/metadata)