### PR TITLE
Notebook pages: upload html directory only

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -5,8 +5,8 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
-  # pull_request:
-  #   branches: ["main"]
+  pull_request:
+    branches: ["main"]
     
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -44,12 +44,15 @@ jobs:
           pip install -r requirements.txt
           jb build . -W
       - name: Setup Pages
+        if: github.event_name == "push"
         uses: actions/configure-pages@v3        
       - name: Upload artifact
+        if: github.event_name == "push"
         uses: actions/upload-pages-artifact@v1
         with:
           # Upload entire repository
           path: './notebooks/_build/html'
       - name: Deploy to GitHub Pages
+        if: github.event_name == "push"
         id: deployment
         uses: actions/deploy-pages@v2

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -37,11 +37,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
-          pip install jupyter-book>=0.15.1
       - name: Build pages
         run: |
           wavdb initdb ~/wdb data/.
           cd notebooks
+          pip install -r requirements.txt
           jb build . -W
       - name: Setup Pages
         uses: actions/configure-pages@v3        
@@ -49,7 +49,7 @@ jobs:
         uses: actions/upload-pages-artifact@v1
         with:
           # Upload entire repository
-          path: './notebooks/_build'
+          path: './notebooks/_build/html'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -44,15 +44,15 @@ jobs:
           pip install -r requirements.txt
           jb build . -W
       - name: Setup Pages
-        if: github.event_name == "push"
+        if: github.event_name == 'push'
         uses: actions/configure-pages@v3        
       - name: Upload artifact
-        if: github.event_name == "push"
+        if: github.event_name == 'push'
         uses: actions/upload-pages-artifact@v1
         with:
-          # Upload entire repository
+          # Upload html output
           path: './notebooks/_build/html'
       - name: Deploy to GitHub Pages
-        if: github.event_name == "push"
+        if: github.event_name == 'push'
         id: deployment
         uses: actions/deploy-pages@v2

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -38,9 +38,3 @@ jobs:
       run: |
         wavdb initdb ./tmp data/.
         wavdb import ./tmp data/.          
-    - name: Test notebooks
-      run: |
-        wavdb initdb ~/wdb data/.
-        cd notebooks
-        pip install -r requirements.txt
-        jb build . -W

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -42,5 +42,5 @@ jobs:
       run: |
         wavdb initdb ~/wdb data/.
         cd notebooks
-        pip install jupyter-book>=0.15.1
+        pip install -r requirements.txt
         jb build . -W

--- a/notebooks/requirements.txt
+++ b/notebooks/requirements.txt
@@ -1,0 +1,1 @@
+jupyter-book>=0.15.1


### PR DESCRIPTION
PR to build notebooks with Jupyter Notebook and upload to GitHub pages. Based on Don's PR: https://github.com/mdenolle/NoisePy/pull/130.

I'm working it out in this repo since I'm an admin and can make the required settings changes. 

**1. Enable pages in `Settings->Pages` and configure them to use GitHub actions:**
<img width="741" alt="image" src="https://github.com/uw-ssec/uwloc-db/assets/10456546/b016ea93-352e-47e2-aa33-9a960f4b7a45">

**2. allow additional branches to publish pages (`Settings->Environments->github-pages`):**
<img width="1171" alt="image" src="https://github.com/uw-ssec/uwloc-db/assets/10456546/8b9fe631-7183-43fe-85bd-61eff221d11e">


